### PR TITLE
Unsubscribe on agent disconnection

### DIFF
--- a/server/models/agent.js
+++ b/server/models/agent.js
@@ -11,6 +11,8 @@ function Agent(obj){
     agents[obj.id] = this; // auto-save. TODO: garbage collect
     this.credentials = obj.credentials;
     this.isConnected = obj.isConnected;
+    
+    this.subscriptions = {}; // list of subscriptions
 
     if(obj.client){
       this.client = obj.client;
@@ -67,6 +69,7 @@ agent.prototype.requireConnection = function(timeout){
 agent.prototype.subscribe = function(channel){
   this.subscriptionResponse(channel, true);
   channel.subscribe(this);
+  this.subscriptions[channel.name] = channel;
 };
 
 agent.prototype.subscriptionDenied = function(channel, reason){

--- a/server/push-it.js
+++ b/server/push-it.js
@@ -235,6 +235,11 @@ extend(PushIt.prototype, {
         if(err){ 
           console.log("Error getting agent "+ agentId + " on disconnect.");
         }else{
+          // unsubscribe from channels
+          for(var channelName in agent.subscriptions){
+            channel = agent.subscriptions[channelName];
+            self.subscriptionManager.unsubscribe(channel, agent);
+          }
           Agent.remove(agentId);
           self.onDisconnect(agent);
         }


### PR DESCRIPTION
This commit fixes #14 by tracking subscriptions in the Agent model and unsubscribing from those channels on disconnection.

BUT, it now presents another issue: once a channel's subscribers drops to zero, subsequent new subscribers to that channel are no longer able to send messages. I'm not sure if that's an issue with InMemoryMQ or somewhere else, but I thought I'd open the pull request to see if you had any ideas.
