### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Self-contained on the client.  On the server, Push-It is tested with Node 0.4.7
   
   
 ## Workflow
-###1. An agent connects
+### 1. An agent connects
 
       PushIt.onConnectionRequest = function(agent){}
   
@@ -82,7 +82,7 @@ Self-contained on the client.  On the server, Push-It is tested with Node 0.4.7
   3. if they are invalid or you have an error, call agent.connectionDenied(reason)
   4. if you do not call disconnect or connected, they will be denied after pushIt.TIMEOUTS.onConnectionRequest milliseconds
 
-###2. An agent subscribes to channels
+### 2. An agent subscribes to channels
 
   The system will use the channel-specific function if the channel and function exist and will fall back to the default otherwise.
     
@@ -94,7 +94,7 @@ Self-contained on the client.  On the server, Push-It is tested with Node 0.4.7
   3. if the agent is not allowed to receive on this channel,  call agent.subscriptionDenied(channel, reason)
   4. if you do not call subscribe or subscriptionDenied, they will be automatically disconnected after pushIt.TIMEOUTS.onSubscriptionRequest milliseconds
     
-###3. An agent publishes to channels
+### 3. An agent publishes to channels
   
   The system will use the channel-specific function if the channel and function exist and will fall back to the default otherwise.
     
@@ -107,7 +107,7 @@ Self-contained on the client.  On the server, Push-It is tested with Node 0.4.7
   4. if the agent is not allowed to publish on this channel,  call agent.publicationDenied(message, reason)
   5. if you do not call agent.publicationDenied or agent.publicationSuccess, then a publicationDenied will be automatically sent  after pushIt.TIMEOUTS.onPublicationRequest milliseconds
   
-###4. An message is sent to a channel where an agent has a subscription.
+### 4. An message is sent to a channel where an agent has a subscription.
   
         Agent.onMessageReceived = function(channel, agent, message){}
   
@@ -116,11 +116,11 @@ Self-contained on the client.  On the server, Push-It is tested with Node 0.4.7
 
   NOTE: this callback is unlike the others.  there is no timeout or failure condition.  you can silently drop messages and nobody will be informed.  This is useful if you want to perform some JIT transformation of messages before delivery to agents.
   
-###5. An agent unsubscribes to channels
+### 5. An agent unsubscribes to channels
 
   This is the same as subscription, except with the names changed to Unsubscribe and Unsubscription.
   
-###6. An agent disconnects
+### 6. An agent disconnects
 
     PushIt.onDisconnect(agent)
   


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
